### PR TITLE
My sinatra-twitter-oauth admited Sinatra app under sub-path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ rdoc
 pkg
 
 ## PROJECT::SPECIFIC
+
+## RVMRC
+.rvmrc

--- a/lib/sinatra-twitter-oauth.rb
+++ b/lib/sinatra-twitter-oauth.rb
@@ -29,7 +29,7 @@ module Sinatra
     def self.registered app  # :nodoc:
     
       app.helpers Helpers
-      app.use Rack::Session::Pool
+      app.use Rack::Session::Pool, :key => 'rack.session'
       app.set :twitter_oauth_config, DEFAULT_CONFIG
         
       app.get '/login' do

--- a/lib/sinatra-twitter-oauth.rb
+++ b/lib/sinatra-twitter-oauth.rb
@@ -22,13 +22,14 @@ module Sinatra
       :key      => 'changeme',
       :secret   => 'changeme',
       :callback => 'changeme',
-      :login_template => {:text=>'<a href="/connect">Login using Twitter</a>'}
+      :login_template => {:text=>'<a href="/connect">Login using Twitter</a>'},
+      :prefix => ""
     }
   
     def self.registered app  # :nodoc:
     
       app.helpers Helpers
-      app.enable :sessions
+      app.use Rack::Session::Pool
       app.set :twitter_oauth_config, DEFAULT_CONFIG
         
       app.get '/login' do

--- a/lib/sinatra-twitter-oauth.rb
+++ b/lib/sinatra-twitter-oauth.rb
@@ -9,11 +9,12 @@ require 'sinatra-twitter-oauth/helpers'
 # using twitter oauth for login
 #
 #twitter_oauth_config
-#options
+#settings
 # key -- oauth consumer key
 # secret -- oauth consumer secret
 # callback -- oauth callback url. Must be absolute. e.g. http://example.com/auth
 # login_template -- a single entry hash with the engine as the key e.g. :login_template => {:haml => :login}
+# prefix -- add prefix to redirect url path
 module Sinatra
   module TwitterOAuth
   
@@ -31,9 +32,9 @@ module Sinatra
       app.set :twitter_oauth_config, DEFAULT_CONFIG
         
       app.get '/login' do
-        redirect '/' if user
+        redirect login_url_for '/' if user
         
-        login_template = options.twitter_oauth_config[:login_template]
+        login_template = settings.twitter_oauth_config[:login_template]
         
         engine = login_template.keys.first
         

--- a/lib/sinatra-twitter-oauth.rb
+++ b/lib/sinatra-twitter-oauth.rb
@@ -51,7 +51,7 @@ module Sinatra
 
       app.get '/auth' do
         if authenticate!
-          redirect '/'
+          redirect login_url_for '/'
         else
           status 403
           'Not Authenticated'
@@ -60,7 +60,7 @@ module Sinatra
       
       app.get '/logout' do
         clear_oauth_session
-        redirect '/login'
+        redirect login_url_for '/login'
       end
     end
     

--- a/lib/sinatra-twitter-oauth/helpers.rb
+++ b/lib/sinatra-twitter-oauth/helpers.rb
@@ -5,7 +5,7 @@ module Sinatra::TwitterOAuth
 
     # relative url based option
     def login_url_for(url)
-      prefix = options.twitter_oauth_config[:prefix] || ""
+      prefix = settings.twitter_oauth_config[:prefix] || ""
       "#{prefix}#{url}"
     end
    
@@ -27,8 +27,8 @@ module Sinatra::TwitterOAuth
 
     def setup_client # :nodoc:
       @client ||= ::TwitterOAuth::Client.new(
-        :consumer_secret => options.twitter_oauth_config[:secret],
-        :consumer_key => options.twitter_oauth_config[:key],
+        :consumer_secret => settings.twitter_oauth_config[:secret],
+        :consumer_key => settings.twitter_oauth_config[:key],
         :token  => session[:access_token],
         :secret => session[:secret_token]
       )
@@ -38,7 +38,7 @@ module Sinatra::TwitterOAuth
       setup_client
       
       begin
-        @client.authentication_request_token(:oauth_callback=>options.twitter_oauth_config[:callback])
+        @client.authentication_request_token(:oauth_callback=>settings.twitter_oauth_config[:callback])
       rescue StandardError => e
         halt 500,'check your key & secret'
       end

--- a/lib/sinatra-twitter-oauth/helpers.rb
+++ b/lib/sinatra-twitter-oauth/helpers.rb
@@ -17,8 +17,8 @@ module Sinatra::TwitterOAuth
     # Redirects to login unless there is an authenticated user
     def login_required
       setup_client
-
-      @user = ::TwitterOAuth::User.new(@client, session[:user]) if session[:user]
+      session_h = session.to_hash
+      @user = ::TwitterOAuth::User.new(@client, session_h[:user]) if session_h[:user]
       
       @rate_limit_status = @client.rate_limit_status
 

--- a/lib/sinatra-twitter-oauth/helpers.rb
+++ b/lib/sinatra-twitter-oauth/helpers.rb
@@ -2,7 +2,13 @@ module Sinatra::TwitterOAuth
   #Helpers exposed by the extension.
   #
   module Helpers
-    
+
+    # relative url based option
+    def login_url_for(url)
+      prefix = options.twitter_oauth_config[:prefix] || ""
+      "#{prefix}#{url}"
+    end
+   
     # The current logged in user
     def user
       @user
@@ -16,10 +22,9 @@ module Sinatra::TwitterOAuth
       
       @rate_limit_status = @client.rate_limit_status
       
-      redirect '/login' unless user
+      redirect login_url_for '/login' unless user
     end
-    
-    
+
     def setup_client # :nodoc:
       @client ||= ::TwitterOAuth::Client.new(
         :consumer_secret => options.twitter_oauth_config[:secret],

--- a/lib/sinatra-twitter-oauth/helpers.rb
+++ b/lib/sinatra-twitter-oauth/helpers.rb
@@ -17,7 +17,7 @@ module Sinatra::TwitterOAuth
     # Redirects to login unless there is an authenticated user
     def login_required
       setup_client
-      
+
       @user = ::TwitterOAuth::User.new(@client, session[:user]) if session[:user]
       
       @rate_limit_status = @client.rate_limit_status
@@ -61,10 +61,9 @@ module Sinatra::TwitterOAuth
     # gets the request token and redirects to twitter's OAuth endpoint
     def redirect_to_twitter_auth_url
       request_token = get_request_token
-    
       session[:request_token] = request_token.token
       session[:request_token_secret]= request_token.secret
-    
+
       redirect request_token.authorize_url.gsub('authorize','authenticate')
     end
     

--- a/lib/sinatra-twitter-oauth/helpers.rb
+++ b/lib/sinatra-twitter-oauth/helpers.rb
@@ -17,7 +17,8 @@ module Sinatra::TwitterOAuth
     # Redirects to login unless there is an authenticated user
     def login_required
       setup_client
-      session_h = session.to_hash
+      session_h = Hash[session.to_hash.map{|key,value| [key.to_sym, value]}]
+
       @user = ::TwitterOAuth::User.new(@client, session_h[:user]) if session_h[:user]
       
       @rate_limit_status = @client.rate_limit_status

--- a/lib/sinatra-twitter-oauth/helpers.rb
+++ b/lib/sinatra-twitter-oauth/helpers.rb
@@ -21,7 +21,7 @@ module Sinatra::TwitterOAuth
       @user = ::TwitterOAuth::User.new(@client, session[:user]) if session[:user]
       
       @rate_limit_status = @client.rate_limit_status
-      
+
       redirect login_url_for '/login' unless user
     end
 

--- a/sinatra-twitter-oauth.gemspec
+++ b/sinatra-twitter-oauth.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
+    s.add_dependency(%q<sinatra>)
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<rspec>, [">= 1.2.9"])
     else

--- a/spec/sinatra-twitter-oauth_spec.rb
+++ b/spec/sinatra-twitter-oauth_spec.rb
@@ -36,7 +36,7 @@ describe Sinatra::TwitterOAuth do
     it 'redirects to /login when unauthenticated' do
       get '/'
       last_response.should be_redirect
-      last_response.location.should == '/login'
+      last_response.location.should =~ /\/login$/
     end
     
     it 'lets you through if you are authed' do
@@ -85,7 +85,7 @@ describe Sinatra::TwitterOAuth do
         @client.stub!(:authorized?).and_return true
         @client.stub!(:info).and_return(mock(:user))
         get '/auth'
-        last_response.location.should == '/'
+        last_response.location.should =~ /\/$/
       end
     end
   end
@@ -93,7 +93,7 @@ describe Sinatra::TwitterOAuth do
   describe "GET /logout" do
     it "redirects to /login" do
       get '/logout',{},@authed_session
-      last_response.location.should == '/login'
+      last_response.location.should =~ /\/login$/
     end
   end
 end


### PR DESCRIPTION
Hi, baroquebobcat.

I forked your repogitory and added some options. If a developer sets option "prefix", my sinatra-twitter-oauth allows a Sinatra app under sub-path to authorize with twitter.

If you like this, please pull my repository.
